### PR TITLE
config: Fix blur enablement logic in blur enable flags

### DIFF
--- a/config/defaults_common.mk
+++ b/config/defaults_common.mk
@@ -16,10 +16,12 @@ PRODUCT_PACKAGES += \
 TARGET_ENABLE_BLUR ?= false
 ifeq ($(TARGET_ENABLE_BLUR),true)
 PRODUCT_SYSTEM_PROPERTIES += \
-    ro.custom.blur.enable=true
+    ro.custom.blur.enable=true \
+    persist.sys.fs.disable_blurs=0
 else
 PRODUCT_SYSTEM_PROPERTIES += \
-    ro.custom.blur.enable=false
+    ro.custom.blur.enable=false \
+    persist.sys.fs.disable_blurs=1
 endif
 
 PRODUCT_SYSTEM_PROPERTIES += ro.surface_flinger.supports_background_blur=1


### PR DESCRIPTION
Set persist.sys.fs.disable_blurs according to the blur build flag to ensure window blurs are correctly enabled or disabled at the framework level.