### PR TITLE
fix build error due to duplicate sysprop assignment

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -265,8 +265,12 @@ endif
 $(call inherit-product, vendor/lineage/audio/audio.mk)
 
 # SetupWizard
+ifneq ($(WITH_GMS),true)
 PRODUCT_PRODUCT_PROPERTIES += \
-    setupwizard.theme=glif_v4 \
+    setupwizard.theme=glif_v4
+endif
+
+PRODUCT_PRODUCT_PROPERTIES += \
     setupwizard.feature.day_night_mode_enabled=true
 
 PRODUCT_ENFORCE_RRO_EXCLUDED_OVERLAYS += vendor/lineage/overlay/no-rro


### PR DESCRIPTION
build error:
```
error: found duplicate sysprop assignments:
setupwizard.theme=glif_v4
setupwizard.theme=glif_expressive
```

since the commit vendor [regeneration enhance](https://gitlab.com/axionaosp/android_vendor_gms/-/commit/a64baaa832d872be946ceadc49b7b7847e63eb2c?file_path=products%2Fgms-props.mk#97a753de2af31eff8e54f83effe986552d0aa6bb
) setupwizard.theme is defined by gms-props.mk, which collides with the previous definition in vendor/lineage/common.mk.
as gms-props.mk is not present in vanilla builds, this commit adds a check for GMS, before trying to assign setupwizard.theme=glif_v4

Change-Id: Iee651d01d7105a8b159f1b2fa166e1a6cc3463b7
